### PR TITLE
fixes button layout if :page_links => false. 

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -31,7 +31,8 @@ module WillPaginate
       end
 
       def previous_or_next_page(page, text, classname)
-        tag :li, link(text, page || '#'), :class => [classname[0..3], classname, ('disabled' unless page)].join(' ')
+        tag :li, link(text, page || '#'),
+	    :class => [(classname[0..3] if  @options[:page_links]), (classname if @options[:page_links]), ('disabled' unless page)].join(' ')
       end
     end
   end


### PR DESCRIPTION
Thanks a alot for the bootstrap-will_paginate gem. Its exactly what I was looking for. 

When I tried it, the next/previous buttons were not shown correctly when passing the :page_links => false option. 

will_paginate provides the option :page_links => false, which makes only the next and previous button is beein rendered (not the page numbers inbetween). 

This commit fixes a broken layout if the option is set to false. 

What do you think about it?
