### PR TITLE
Make gap compatible with latest bootstrap version

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -27,7 +27,7 @@ module WillPaginate
       end
 
       def gap
-        tag :li, link(super, '#'), :class => 'disabled'
+        tag :li, link('&hellip;'.html_safe, '#', :class => 'disabled')
       end
 
       def previous_or_next_page(page, text, classname)


### PR DESCRIPTION
Call to super was creating an extra span tag inside of the a tag rendered by the gap method, affecting display
