### PR TITLE
Fix gap styling

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -27,7 +27,7 @@ module WillPaginate
       end
 
       def gap
-        tag :li, link('&hellip;'.html_safe, '#', :class => 'disabled')
+        tag :li, link('&hellip;'.html_safe, '#'), :class => 'disabled'
       end
 
       def previous_or_next_page(page, text, classname)


### PR DESCRIPTION
Latest commit moved the disabled class down to the a tag.  This moves it back up to the li.
