### PR TITLE
clean up the duplicated .pagination class; fix #17

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -19,7 +19,7 @@ module WillPaginate
       protected
       
       def html_container(html)
-        tag :div, tag(:ul, html, :class => "pagination"), container_attributes
+        tag :ul, html, container_attributes
       end
 
       def page_number(page)


### PR DESCRIPTION
as  #17 describes, by default `bootstrap-will_paginate` will generate a duplicated `.pagination` which enlarges the margins in bootstrap3.

this pr removes the outer `.pagination` wrapper.

but I'm not sure about if it is by design or not. if there is any issue on this modification, please let me know.

thanks
