### PR TITLE
Pagination Styling: Pass additional classes to ul element

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,18 @@ To use Bootstrap 4 version:
 
     <%= will_paginate(@things, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer) %>
 
+### Size and Alignment of the Pagination Component
+
+You can easily change the pagination components' appearance by passing the correct Bootstrap classes as options:
+
+Sizing(Bootstrap 3 & 4): Add `.pagination-lg` or `.pagination-sm` for additional sizes.
+
+    <%= will_paginate(@things, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer, class: 'pagination-lg') %>
+
+Alignment (Bootstrap 4 only): Change the alignment of pagination components using Boostrap 4 Flexbox utilities
+
+    <%= will_paginate(@things, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer, class: 'justify-content-center') %>
+
 Copyright (c) 2017 [Nicholas Fine](https://twitter.com/yrgoldteeth), [Isaac Bowen](http://isaacbowen.com) released under the MIT license
 
 [wp]: https://github.com/mislav/will_paginate

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -19,7 +19,7 @@ module WillPaginate
       protected
 
       def html_container(html)
-        tag :div, tag(:ul, html, :class => "pagination"), container_attributes
+        tag :nav, tag(:ul, html, :class => "pagination"), container_attributes
       end
 
       def page_number(page)

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -19,7 +19,7 @@ module WillPaginate
       protected
 
       def html_container(html)
-        tag :nav, tag(:ul, html, :class => "pagination"), container_attributes
+        tag :nav, tag(:ul, html, class: ul_class)
       end
 
       def page_number(page)
@@ -33,12 +33,16 @@ module WillPaginate
       def previous_or_next_page(page, text, classname)
         tag :li, link(text, page || '#'), :class => [(classname[0..3] if  @options[:page_links]), (classname if @options[:page_links]), ('disabled' unless page)].join(' ')
       end
+
+      def ul_class
+         ["pagination", container_attributes[:class]].compact.join(" ")
+      end
     end
 
     class Bootstrap4LinkRenderer < LinkRenderer
       protected
       def html_container(html)
-        tag :nav, tag(:ul, html, :class => "pagination"), container_attributes
+        tag :nav, tag(:ul, html, class: ul_class)
       end
 
       def page_number(page)
@@ -57,6 +61,10 @@ module WillPaginate
 
       def previous_or_next_page(page, text, classname)
         tag :li, link(text, page || '#', :class => 'page-link'), :class => [(classname[0..3] if  @options[:page_links]), (classname if @options[:page_links]), ('disabled' unless page), 'page-item'].join(' ')
+      end
+
+      def ul_class
+         ["pagination", container_attributes[:class]].compact.join(" ")
       end
     end
   end


### PR DESCRIPTION
According to the Bootstrap Docs, you can change the pagination components' appearance by applying additional classes to the `<ul>` container element.

Those classes should be passed into the will_paginate helper like this:
```html
<%= will_paginate(collection, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer, class: 'pagination-sm') %>
```  

Before this pull request, classes added via the `class:` option were applied to the surrounding container `<nav>` element and had no effect on the pagination appearance.