### PR TITLE
Enhance/previous or next page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,10 @@ To use Bootstrap 4 version:
 
     <%= will_paginate(@things, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer) %>
 
+To use Bootstrap 2 version:
+
+    <%= will_paginate(@things, :renderer => WillPaginate::ActionView::Bootstrap2LinkRenderer) %>
+
 ### Size and Alignment of the Pagination Component
 
 You can easily change the pagination components' appearance by passing the correct Bootstrap classes as options:

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -72,5 +72,30 @@ module WillPaginate
          ["pagination", container_attributes[:class]].compact.join(" ")
       end
     end
+
+    class Bootstrap2LinkRenderer < LinkRenderer
+      protected
+
+      def html_container(html)
+        tag :div, tag(:ul, html), container_attributes
+      end
+
+      def page_number(page)
+        tag :li, link(page, page, :rel => rel_value(page)), :class => ('active' if page == current_page)
+      end
+
+      def gap
+        tag :li, link('&hellip;'.html_safe, '#'), :class => 'disabled'
+      end
+
+      def previous_or_next_page(page, text, classname)
+        if page
+          tag :li, link(text, page),
+            :class => [(classname[0..3] if  @options[:page_links]), (classname if @options[:page_links])].join(' ')
+        else
+          tag :li, tag(:span, text), :class => classname + ' disabled'
+        end
+      end
+    end
   end
 end

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -31,7 +31,12 @@ module WillPaginate
       end
 
       def previous_or_next_page(page, text, classname)
-        tag :li, link(text, page || '#'), :class => [(classname[0..3] if  @options[:page_links]), (classname if @options[:page_links]), ('disabled' unless page)].join(' ')
+        if page
+          tag :li, link(text, page),
+            :class => [(classname[0..3] if  @options[:page_links]), (classname if @options[:page_links])].join(' ')
+        else
+          tag :li, tag(:span, text), :class => classname + ' disabled'
+        end
       end
 
       def ul_class


### PR DESCRIPTION
This PR addresses two issues:

1) Links are still clickable even though they are disabled via CSS
This PR fixes it by making `#previous_or_next_page` return a nested `span` instead of a nested `a`. This is the recommended implementation in the [Bootstrap 2](https://getbootstrap.com/2.3.2/components.html#pagination), [Bootstrap 3](https://getbootstrap.com/docs/3.3/components/#disabled-and-active-states) and [Bootstrap 4](https://getbootstrap.com/docs/4.1/components/pagination/#disabled-and-active-states) documentations.

Referenced from issue #29 

2) Reintroduces support for Bootstrap 2
Would you be okay with having support for some legacy codebases out there? This is entirely up to you- and I'll be happy to remove this commit if you don't feel comfortable having it in your codebase. Just for your reference, I currently need Bootstrap 2 support for your gem.

Let me know what your thoughts are about the concept or the code- will be happy to make any changes :) & thank you for maintaining this gem! 💪 