### PR TITLE
Bootstrap4LinkRenderer is now responsive with small devices

### DIFF
--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -64,7 +64,7 @@ module WillPaginate
       end
 
       def ul_class
-         ["pagination", container_attributes[:class]].compact.join(" ")
+         ["pagination flex-wrap", container_attributes[:class]].compact.join(" ")
       end
     end
   end


### PR DESCRIPTION
There is a problem with the pagination link renderer in Bootstrap 4. Is not responsive using small devices. Adding the class **_flex-wrap_** in the UL with the **_pagination_** class, solve the problem

- Bootstrap4LinkRenderer is now responsive with small devices